### PR TITLE
fix: CI e2e httpbin startup, update Rust deps, suppress unfixed vulns

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: CI
 
-permissions:
-  contents: read
-  security-events: write
-  actions: read
+permissions: {}  # Explicit empty - each job declares its own
 
 on:
   push:
@@ -27,6 +24,8 @@ jobs:
   # ── Stage 1a: Lint Rust ───────────────────────────────────────────
   lint-rust:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -53,6 +52,8 @@ jobs:
   # ── Stage 1b: Lint C ──────────────────────────────────────────────
   lint-c:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -69,6 +70,8 @@ jobs:
   # ── Stage 1c: Lint Shell ──────────────────────────────────────────
   lint-shell:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -80,6 +83,8 @@ jobs:
   # ── Stage 2a: Test Rust ───────────────────────────────────────────
   test-rust:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -104,6 +109,8 @@ jobs:
   # ── Stage 2b: Test Rust Proptests ─────────────────────────────────
   test-rust-proptests:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -122,6 +129,8 @@ jobs:
   # ── Stage 2c: Test C ──────────────────────────────────────────────
   test-c:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -139,6 +148,9 @@ jobs:
   build-containers:
     runs-on: ubuntu-24.04
     needs: [test-rust, test-c]
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -191,6 +203,8 @@ jobs:
   unit-tests:
     runs-on: ubuntu-24.04
     needs: [test-rust, test-c]
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -211,6 +225,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: build-containers
     permissions:
+      contents: read
       security-events: write
     strategy:
       matrix:
@@ -256,6 +271,8 @@ jobs:
   integration-tests:
     runs-on: ubuntu-24.04
     needs: [build-containers, unit-tests]
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -303,6 +320,8 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-24.04
     needs: integration-tests
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -415,6 +434,8 @@ jobs:
   # ── Security: SonarCloud ──────────────────────────────────────────
   security-sonarcloud:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.osv-scanner.toml
+++ b/.osv-scanner.toml
@@ -1,0 +1,10 @@
+# OSV Scanner ignore list
+# Vulnerabilities with no upstream fix available
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2025-0119"
+reason = "number_prefix: no fix available upstream (transitive dep via indicatif)"
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2025-0134"
+reason = "rustls-pemfile: no fix available upstream"

--- a/Justfile
+++ b/Justfile
@@ -96,8 +96,7 @@ test-integration:
 
 # Run E2E tests (requires running containers)
 test-e2e:
-    docker compose --profile test up -d httpbin
-    ./tests/run-tests.sh --ci e2e; rc=$?; docker compose --profile test rm -sf httpbin; exit $rc
+    ./tests/run-tests.sh --ci e2e
 
 # Run all test tiers (unit + integration + e2e)
 test-all: test test-integration test-e2e

--- a/agents/openclaw/scripts/polis-report-block.sh
+++ b/agents/openclaw/scripts/polis-report-block.sh
@@ -9,7 +9,7 @@ DEST="${3:?Missing destination}"
 PATTERN="${4:-}"
 
 ARGS="{\"request_id\":\"${REQ_ID}\",\"reason\":\"${REASON}\",\"destination\":\"${DEST}\""
-[ -n "$PATTERN" ] && ARGS="${ARGS},\"pattern\":\"${PATTERN}\""
+[[ -n "$PATTERN" ]] && ARGS="${ARGS},\"pattern\":\"${PATTERN}\""
 ARGS="${ARGS}}"
 
 exec "$SCRIPT_DIR/polis-toolbox-call.sh" report_block "$ARGS"

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assert_cmd"
@@ -164,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytes"
@@ -212,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.59"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5caf74d17c3aec5495110c34cc3f78644bfa89af6c8993ed4de2790e49b6499"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -222,9 +222,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.59"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "370daa45065b80218950227371916a1633217ae42b2715b2287b606dcd618e24"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstream",
  "anstyle",
@@ -544,6 +544,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,6 +666,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -676,6 +695,15 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
 ]
 
 [[package]]
@@ -919,6 +947,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -946,7 +980,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1022,13 +1058,19 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "c7e709f3e3d22866f9c25b3aff01af289b18422cc8b4262fb19103ee80fe513d"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1049,9 +1091,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1126,9 +1168,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5d26952a508f321b4d3d2e80e78fc2603eaefcdf0c30783867f19586518bdc"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
 dependencies = [
  "libc",
  "log",
@@ -1226,9 +1268,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "owo-colors"
-version = "4.2.3"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 dependencies = [
  "supports-color 2.1.0",
  "supports-color 3.0.2",
@@ -1363,6 +1405,16 @@ checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -1649,9 +1701,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
@@ -1731,9 +1783,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1744,9 +1796,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.16.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321c8673b092a9a42605034a9879d73cb79101ed5fd117bc9a597b89b4e9e61a"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1980,9 +2032,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.116"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df424c70518695237746f84cede799c9c58fcb37450d7b23716568cc8bc69cb"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2027,7 +2079,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2269,6 +2321,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2378,10 +2436,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.108"
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1adf1535672f5b7824f817792b1afd731d7e843d2d04ec8f27e8cb51edd8ac"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2392,9 +2459,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "fe88540d1c934c4ec8e6db0afa536876c5441289d7f9f9123d4f065ac1250a6b"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2406,9 +2473,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "19e638317c08b21663aed4d2b9a2091450548954695ff4efa75bff5fa546b3b1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2416,9 +2483,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "2c64760850114d03d5f65457e96fc988f11f01d38fbaa51b254e4ab5809102af"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2429,18 +2496,52 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "60eecd4fe26177cfa3339eb00b4a36445889ba3ad37080c2429879718e20ca41"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.85"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d6bb20ed2d9572df8584f6dc81d68a41a625cadc6f15999d649a70ce7e3597a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2703,6 +2804,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"

--- a/cli/src/commands/agent.rs
+++ b/cli/src/commands/agent.rs
@@ -137,7 +137,10 @@ fn validate_agent_folder(path: &str) -> Result<String> {
     let manifest: AgentManifest = serde_yaml::from_str(&content)
         .context("failed to parse agent.yaml: missing or invalid metadata.name")?;
 
-    anyhow::ensure!(!manifest.metadata.name.is_empty(), "metadata.name is empty in agent.yaml");
+    anyhow::ensure!(
+        !manifest.metadata.name.is_empty(),
+        "metadata.name is empty in agent.yaml"
+    );
     validate_agent_name(&manifest.metadata.name)?;
     Ok(manifest.metadata.name)
 }

--- a/cli/src/commands/doctor.rs
+++ b/cli/src/commands/doctor.rs
@@ -257,7 +257,11 @@ pub async fn run_with(
 
 /// Build and print JSON output for doctor checks.
 fn print_json_output(checks: &DoctorChecks, issues: &[String]) -> Result<()> {
-    let status = if issues.is_empty() { "healthy" } else { "unhealthy" };
+    let status = if issues.is_empty() {
+        "healthy"
+    } else {
+        "unhealthy"
+    };
     let out = serde_json::json!({
         "status": status,
         "checks": {
@@ -296,7 +300,12 @@ fn print_json_output(checks: &DoctorChecks, issues: &[String]) -> Result<()> {
 }
 
 /// Print human-readable doctor output.
-fn print_human_output(ctx: &OutputContext, checks: &DoctorChecks, issues: &[String], verbose: bool) {
+fn print_human_output(
+    ctx: &OutputContext,
+    checks: &DoctorChecks,
+    issues: &[String],
+    verbose: bool,
+) {
     println!();
     println!("  {}", "Polis Health Check".style(ctx.styles.header));
     println!();
@@ -325,7 +334,11 @@ fn print_summary(ctx: &OutputContext, issues: &[String], verbose: bool) {
         println!("  {} Everything looks good!", "✓".style(ctx.styles.success));
         return;
     }
-    let hint = if verbose { "" } else { " Run with --verbose for details." };
+    let hint = if verbose {
+        ""
+    } else {
+        " Run with --verbose for details."
+    };
     println!(
         "  {} Found {} issues.{hint}",
         "✗".style(ctx.styles.error),

--- a/cli/src/commands/doctor.rs
+++ b/cli/src/commands/doctor.rs
@@ -246,88 +246,97 @@ pub async fn run_with(
         security,
     };
     let issues = collect_issues(&checks);
-    let status = if issues.is_empty() {
-        "healthy"
-    } else {
-        "unhealthy"
-    };
 
     if json {
-        let out = serde_json::json!({
-            "status": status,
-            "checks": {
-                "prerequisites": {
-                    "multipass_found": checks.prerequisites.multipass_found,
-                    "multipass_version": checks.prerequisites.multipass_version,
-                    "multipass_version_ok": checks.prerequisites.multipass_version_ok,
-                    "removable_media_connected": checks.prerequisites.removable_media_connected,
-                },
-                "workspace": {
-                    "ready": checks.workspace.ready,
-                    "disk_space_gb": checks.workspace.disk_space_gb,
-                    "disk_space_ok": checks.workspace.disk_space_ok,
-                    "image": checks.workspace.image,
-                },
-                "network": {
-                    "internet": checks.network.internet,
-                    "dns": checks.network.dns,
-                },
-                "security": {
-                    "process_isolation": checks.security.process_isolation,
-                    "traffic_inspection": checks.security.traffic_inspection,
-                    "malware_db_current": checks.security.malware_db_current,
-                    "malware_db_age_hours": checks.security.malware_db_age_hours,
-                    "certificates_valid": checks.security.certificates_valid,
-                    "certificates_expire_days": checks.security.certificates_expire_days,
-                },
-            },
-            "issues": issues,
-        });
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&out).context("JSON serialization")?
-        );
-        return Ok(());
+        print_json_output(&checks, &issues)?;
+    } else {
+        print_human_output(ctx, &checks, &issues, verbose);
     }
+    Ok(())
+}
 
+/// Build and print JSON output for doctor checks.
+fn print_json_output(checks: &DoctorChecks, issues: &[String]) -> Result<()> {
+    let status = if issues.is_empty() { "healthy" } else { "unhealthy" };
+    let out = serde_json::json!({
+        "status": status,
+        "checks": {
+            "prerequisites": {
+                "multipass_found": checks.prerequisites.multipass_found,
+                "multipass_version": checks.prerequisites.multipass_version,
+                "multipass_version_ok": checks.prerequisites.multipass_version_ok,
+                "removable_media_connected": checks.prerequisites.removable_media_connected,
+            },
+            "workspace": {
+                "ready": checks.workspace.ready,
+                "disk_space_gb": checks.workspace.disk_space_gb,
+                "disk_space_ok": checks.workspace.disk_space_ok,
+                "image": checks.workspace.image,
+            },
+            "network": {
+                "internet": checks.network.internet,
+                "dns": checks.network.dns,
+            },
+            "security": {
+                "process_isolation": checks.security.process_isolation,
+                "traffic_inspection": checks.security.traffic_inspection,
+                "malware_db_current": checks.security.malware_db_current,
+                "malware_db_age_hours": checks.security.malware_db_age_hours,
+                "certificates_valid": checks.security.certificates_valid,
+                "certificates_expire_days": checks.security.certificates_expire_days,
+            },
+        },
+        "issues": issues,
+    });
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&out).context("JSON serialization")?
+    );
+    Ok(())
+}
+
+/// Print human-readable doctor output.
+fn print_human_output(ctx: &OutputContext, checks: &DoctorChecks, issues: &[String], verbose: bool) {
     println!();
     println!("  {}", "Polis Health Check".style(ctx.styles.header));
     println!();
 
     print_prerequisites_section(ctx, &checks.prerequisites);
     print_workspace_section(ctx, &checks.workspace);
-
-    println!("  Network:");
-    print_check(ctx, checks.network.internet, "Internet connectivity");
-    print_check(ctx, checks.network.dns, "DNS resolution working");
-    println!();
-
+    print_network_section(ctx, &checks.network);
     print_security_section(ctx, &checks.security);
+    print_summary(ctx, issues, verbose);
 
+    println!();
+}
+
+/// Print the network section of the human-readable health report.
+fn print_network_section(ctx: &OutputContext, net: &NetworkChecks) {
+    println!("  Network:");
+    print_check(ctx, net.internet, "Internet connectivity");
+    print_check(ctx, net.dns, "DNS resolution working");
+    println!();
+}
+
+/// Print the summary section with issues.
+fn print_summary(ctx: &OutputContext, issues: &[String], verbose: bool) {
     println!();
     if issues.is_empty() {
         println!("  {} Everything looks good!", "✓".style(ctx.styles.success));
-    } else {
-        let hint = if verbose {
-            ""
-        } else {
-            " Run with --verbose for details."
-        };
-        println!(
-            "  {} Found {} issues.{hint}",
-            "✗".style(ctx.styles.error),
-            issues.len(),
-        );
-        if verbose {
-            println!();
-            for issue in &issues {
-                println!("    {} {issue}", "✗".style(ctx.styles.error));
-            }
+        return;
+    }
+    let hint = if verbose { "" } else { " Run with --verbose for details." };
+    println!(
+        "  {} Found {} issues.{hint}",
+        "✗".style(ctx.styles.error),
+        issues.len(),
+    );
+    if verbose {
+        println!();
+        for issue in issues {
+            println!("    {} {issue}", "✗".style(ctx.styles.error));
         }
     }
-    println!();
-
-    Ok(())
 }
 
 /// Print the prerequisites section of the human-readable health report.

--- a/cli/tests/unit/config_command.rs
+++ b/cli/tests/unit/config_command.rs
@@ -306,9 +306,14 @@ async fn test_config_set_propagation_passes_level_as_separate_arg() {
     assert!(set_call.contains(&"SET".to_string()));
     assert!(set_call.contains(&"polis:config:security_level".to_string()));
     assert!(set_call.contains(&"strict".to_string()));
+    // Password passed via REDISCLI_AUTH env var (not -a flag) to avoid process list exposure
     assert!(
-        set_call.contains(&"testpass".to_string()),
-        "password should be passed as arg"
+        set_call.iter().any(|a| a.starts_with("REDISCLI_AUTH=")),
+        "password should be passed via REDISCLI_AUTH env var, got: {set_call:?}"
+    );
+    assert!(
+        !set_call.contains(&"-a".to_string()),
+        "-a flag should not be used (exposes password in process list)"
     );
 }
 

--- a/packer/scripts/install-agents.sh
+++ b/packer/scripts/install-agents.sh
@@ -12,7 +12,7 @@ if [[ -f "${AGENTS_TAR}" ]]; then
     rm -f "${AGENTS_TAR}"
     echo "==> Agents installed:"
     for d in agents/*/; do
-        [ -d "$d" ] || continue
+        [[ -d "$d" ]] || continue
         name=$(basename "$d")
         echo "    - ${name}"
     done

--- a/packer/scripts/install-sysbox.sh
+++ b/packer/scripts/install-sysbox.sh
@@ -14,8 +14,8 @@ DEB_URL="https://github.com/nestybox/sysbox/releases/download/v${SYSBOX_VERSION}
 
 echo "==> Installing Sysbox ${SYSBOX_VERSION} (${ARCH})..."
 
-# Download Sysbox .deb
-curl -fsSL -o "/tmp/${DEB_NAME}" "${DEB_URL}"
+# Download Sysbox .deb (HTTPS + SHA256 verified below)
+curl -fsSL -o "/tmp/${DEB_NAME}" "${DEB_URL}"  # NOSONAR - URL is HTTPS, checksum verified
 
 # Verify SHA256
 ACTUAL_SHA256=$(sha256sum "/tmp/${DEB_NAME}" | awk '{print $1}')

--- a/services/gate/scripts/init.sh
+++ b/services/gate/scripts/init.sh
@@ -14,17 +14,18 @@ validate_certificates() {
     local ca_cert="/etc/g3proxy/ssl/ca.pem"
     
     if [[ ! -f "$ca_cert" ]]; then
-        echo "[gateway] ERROR: CA certificate not found: $ca_cert"
+        echo "[gateway] ERROR: CA certificate not found: $ca_cert" >&2
         exit 1
     fi
     
     # Validate certificate is not expired
     if ! openssl x509 -checkend 86400 -noout -in "$ca_cert" 2>/dev/null; then
-        echo "[gateway] ERROR: CA certificate expires within 24 hours"
+        echo "[gateway] ERROR: CA certificate expires within 24 hours" >&2
         exit 1
     fi
     
     echo "[gateway] Certificate validation passed"
+    return 0
 }
 
 # Run validation first

--- a/services/gate/scripts/setup-network.sh
+++ b/services/gate/scripts/setup-network.sh
@@ -15,8 +15,8 @@ EXTERNAL_SUBNET="10.20.1.0/24"
 
 # Detect internal interface (bridge connected to workspace)
 INTERNAL_IF=$(ip -4 route show "$INTERNAL_SUBNET" | awk '{print $3}' | head -n 1)
-if [ -z "$INTERNAL_IF" ]; then
-    echo "[gate-init] ERROR: Could not detect internal interface for $INTERNAL_SUBNET"
+if [[ -z "$INTERNAL_IF" ]]; then
+    echo "[gate-init] ERROR: Could not detect internal interface for $INTERNAL_SUBNET" >&2
     exit 1
 fi
 echo "[gate-init] Detected internal interface: $INTERNAL_IF"

--- a/services/sentinel/modules/approval/srv_polis_approval.c
+++ b/services/sentinel/modules/approval/srv_polis_approval.c
@@ -416,6 +416,7 @@ int approval_init_service(ci_service_xdata_t *srv_xdata,
         /* Authenticate with ACL: AUTH governance-respmod <password> */
         reply = redisCommand(valkey_ctx,
             "AUTH governance-respmod %s", vk_pass);
+        memset(vk_pass, 0, sizeof(vk_pass));  /* Scrub password from stack */
         if (reply == NULL || reply->type == REDIS_REPLY_ERROR) {
             ci_debug_printf(1, "polis_approval: WARNING: "
                 "Valkey ACL auth failed%s%s — "
@@ -498,6 +499,7 @@ static int ensure_valkey_connected(void)
 
             reply = redisCommand(valkey_ctx,
                 "AUTH governance-respmod %s", vk_pass);
+            memset(vk_pass, 0, sizeof(vk_pass));  /* Scrub password from stack */
             if (reply == NULL ||
                 reply->type == REDIS_REPLY_ERROR) {
                 ci_debug_printf(1, "polis_approval: WARNING: "

--- a/services/sentinel/modules/approval/srv_polis_approval_rewrite.c
+++ b/services/sentinel/modules/approval/srv_polis_approval_rewrite.c
@@ -333,6 +333,7 @@ int rewrite_init_service(ci_service_xdata_t *srv_xdata,
         /* Authenticate with ACL: AUTH governance-reqmod <password> */
         reply = redisCommand(valkey_ctx,
             "AUTH governance-reqmod %s", vk_pass);
+        memset(vk_pass, 0, sizeof(vk_pass));  /* Scrub password from stack */
         if (reply == NULL || reply->type == REDIS_REPLY_ERROR) {
             ci_debug_printf(1, "polis_approval_rewrite: WARNING: "
                 "Valkey ACL auth failed%s%s — "
@@ -416,6 +417,7 @@ static int ensure_valkey_connected(void)
             
             reply = redisCommand(valkey_ctx,
                 "AUTH governance-reqmod %s", vk_pass);
+            memset(vk_pass, 0, sizeof(vk_pass));  /* Scrub password from stack */
             if (reply == NULL ||
                 reply->type == REDIS_REPLY_ERROR) {
                 ci_debug_printf(1,

--- a/services/state/scripts/health.sh
+++ b/services/state/scripts/health.sh
@@ -42,7 +42,7 @@ if ! echo "${VALKEY_PORT}" | grep -qE '^[0-9]+$'; then
     echo "CRITICAL: Invalid VALKEY_PORT '${VALKEY_PORT}' (not numeric)"
     exit 1
 fi
-if [ "${VALKEY_PORT}" -lt 1 ] || [ "${VALKEY_PORT}" -gt 65535 ]; then
+if [[ "${VALKEY_PORT}" -lt 1 || "${VALKEY_PORT}" -gt 65535 ]]; then
     echo "CRITICAL: Invalid VALKEY_PORT '${VALKEY_PORT}' (out of range 1-65535)"
     exit 1
 fi
@@ -53,12 +53,12 @@ fi
 # (not visible in ps aux output)
 # =============================================================================
 
-if [ ! -f "${VALKEY_PASSWORD_FILE}" ]; then
+if [[ ! -f "${VALKEY_PASSWORD_FILE}" ]]; then
     echo "CRITICAL: Password file not found: ${VALKEY_PASSWORD_FILE}"
     exit 1
 fi
 
-REDISCLI_AUTH="$(cat "${VALKEY_PASSWORD_FILE}" | tr -d '[:space:]')"
+REDISCLI_AUTH="$(tr -d '[:space:]' < "${VALKEY_PASSWORD_FILE}")"
 export REDISCLI_AUTH
 
 # =============================================================================
@@ -82,7 +82,7 @@ CLI_ARGS=(
 
 PING_RESULT="$(valkey-cli "${CLI_ARGS[@]}" ping 2>&1)" || true
 
-if [ "${PING_RESULT}" != "PONG" ]; then
+if [[ "${PING_RESULT}" != "PONG" ]]; then
     echo "CRITICAL: Valkey not responding (expected PONG, got '${PING_RESULT}')"
     exit 1
 fi
@@ -105,11 +105,11 @@ MAXMEMORY="$(echo "${MEMORY_INFO}" \
     | tr -d '[:space:]')"
 
 # Only check memory pressure if maxmemory is configured (non-zero)
-if [ -n "${MAXMEMORY}" ] && [ "${MAXMEMORY}" -gt 0 ] 2>/dev/null; then
-    if [ -n "${USED_MEMORY}" ]; then
+if [[ -n "${MAXMEMORY}" && "${MAXMEMORY}" -gt 0 ]] 2>/dev/null; then
+    if [[ -n "${USED_MEMORY}" ]]; then
         # Calculate percentage: (used * 100) / max
         MEMORY_PERCENT=$(( (USED_MEMORY * 100) / MAXMEMORY ))
-        if [ "${MEMORY_PERCENT}" -ge "${MEMORY_WARN_PERCENT}" ]; then
+        if [[ "${MEMORY_PERCENT}" -ge "${MEMORY_WARN_PERCENT}" ]]; then
             echo "WARNING: Memory usage at ${MEMORY_PERCENT}% (threshold: ${MEMORY_WARN_PERCENT}%)"
             exit 1
         fi
@@ -128,7 +128,7 @@ AOF_ENABLED="$(echo "${PERSIST_INFO}" \
     | cut -d: -f2 \
     | tr -d '[:space:]')"
 
-if [ "${AOF_ENABLED}" != "1" ]; then
+if [[ "${AOF_ENABLED}" != "1" ]]; then
     echo "CRITICAL: AOF persistence disabled"
     exit 1
 fi

--- a/services/toolbox/Cargo.lock
+++ b/services/toolbox/Cargo.lock
@@ -72,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-swap"
@@ -131,9 +131,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.4"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
+checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -250,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytes"
@@ -315,9 +315,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.59"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5caf74d17c3aec5495110c34cc3f78644bfa89af6c8993ed4de2790e49b6499"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -325,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.59"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "370daa45065b80218950227371916a1633217ae42b2715b2287b606dcd618e24"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1026,9 +1026,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "c7e709f3e3d22866f9c25b3aff01af289b18422cc8b4262fb19103ee80fe513d"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1414,9 +1414,9 @@ checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "redis"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e969d1d702793536d5fda739a82b88ad7cbe7d04f8386ee8cd16ad3eff4854a5"
+checksum = "dbe7f6e08ce1c6a9b21684e643926f6fc3b683bc006cb89afd72a5e0eb16e3a2"
 dependencies = [
  "arcstr",
  "bytes",
@@ -1681,9 +1681,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1694,9 +1694,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.16.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321c8673b092a9a42605034a9879d73cb79101ed5fd117bc9a597b89b4e9e61a"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1881,9 +1881,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.116"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df424c70518695237746f84cede799c9c58fcb37450d7b23716568cc8bc69cb"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2224,9 +2224,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "ec1adf1535672f5b7824f817792b1afd731d7e843d2d04ec8f27e8cb51edd8ac"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2237,9 +2237,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "19e638317c08b21663aed4d2b9a2091450548954695ff4efa75bff5fa546b3b1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2247,9 +2247,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "2c64760850114d03d5f65457e96fc988f11f01d38fbaa51b254e4ab5809102af"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2260,9 +2260,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "60eecd4fe26177cfa3339eb00b4a36445889ba3ad37080c2429879718e20ca41"
 dependencies = [
  "unicode-ident",
 ]

--- a/tests/lib/guards.bash
+++ b/tests/lib/guards.bash
@@ -65,9 +65,10 @@ relax_security_level() {
                 --user mcp-admin --no-auth-warning \
                 SET polis:config:security_level relaxed EX $ttl" 2>/dev/null; then
             # Warmup: wait for proxy to stabilise after security level change
+            # HTTP is intentional - testing TPROXY interception of plain HTTP traffic
             for _i in 1 2 3; do
                 docker exec "$CTR_WORKSPACE" curl -sf -o /dev/null --connect-timeout 5 \
-                    --proxy "http://${IP_GATE_INT}:8080" "http://${HTTPBIN_HOST}/get" 2>/dev/null && return
+                    --proxy "http://${IP_GATE_INT}:8080" "http://${HTTPBIN_HOST}/get" 2>/dev/null && return  # NOSONAR
                 sleep 1
             done
             return 0

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -60,19 +60,15 @@ case "$TIER" in
     packer)      run_tier "unit/packer" ;;
     docker)      run_tier "unit/docker" ;;
     e2e)
-        if [[ "$CI_MODE" != "true" ]]; then
-            docker compose --profile test pull httpbin 2>/dev/null || true
-            docker compose --profile test up -d httpbin
-            trap 'docker compose --profile test rm -sf httpbin 2>/dev/null || true' EXIT
-        fi
+        docker compose --profile test pull httpbin 2>/dev/null || true
+        docker compose --profile test up -d httpbin
+        [[ "$CI_MODE" != "true" ]] && trap 'docker compose --profile test rm -sf httpbin 2>/dev/null || true' EXIT
         run_tier "e2e"
         ;;
     all)
-        if [[ "$CI_MODE" != "true" ]]; then
-            docker compose --profile test pull httpbin 2>/dev/null || true
-            docker compose --profile test up -d httpbin
-            trap 'docker compose --profile test rm -sf httpbin 2>/dev/null || true' EXIT
-        fi
+        docker compose --profile test pull httpbin 2>/dev/null || true
+        docker compose --profile test up -d httpbin
+        [[ "$CI_MODE" != "true" ]] && trap 'docker compose --profile test rm -sf httpbin 2>/dev/null || true' EXIT
         run_tier "unit"
         run_tier "integration"
         run_tier "e2e"


### PR DESCRIPTION
- Fix run-tests.sh to start httpbin in CI mode
- Remove duplicate httpbin management from Justfile  
- cargo update for cli and toolbox crates
- Add .osv-scanner.toml to ignore RUSTSEC-2025-0119, RUSTSEC-2025-0134 (no upstream fix available)