### PR TITLE
feat: upload VM image to S3/CloudFront CDN on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,11 +309,50 @@ jobs:
           retention-days: 1
 
   # =========================================================
+  # Upload VM image to S3 / CloudFront CDN
+  # =========================================================
+  cdn:
+    name: Upload to CDN
+    needs: [validate, vm]
+    runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+    steps:
+      - name: Download VM artifact
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: vm-image
+          path: ./vm
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Upload VM image to S3
+        run: |
+          VERSION="${{ needs.validate.outputs.version }}"
+          QCOW2=$(ls vm/*.qcow2 | head -1)
+          aws s3 cp "${QCOW2}" \
+            "s3://polis-releases/${VERSION}/polis-${VERSION}-amd64.qcow2" \
+            --no-progress
+          echo "✓ Uploaded to s3://polis-releases/${VERSION}/"
+
+      - name: Invalidate CloudFront cache
+        run: |
+          VERSION="${{ needs.validate.outputs.version }}"
+          aws cloudfront create-invalidation \
+            --distribution-id "${{ secrets.CLOUDFRONT_DIST_ID }}" \
+            --paths "/${VERSION}/*"
+          echo "✓ CloudFront cache invalidated for /${VERSION}/*"
+
+  # =========================================================
   # Create GitHub Release
   # =========================================================
   release:
     name: Create Release
-    needs: [validate, vm, cli]
+    needs: [validate, vm, cli, cdn]
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

Moves VM image hosting from GitHub Releases to S3 + CloudFront CDN for faster downloads (GitHub Releases CDN is not optimized for large binaries like the 1.7GB qcow2).

## Changes

### `.github/workflows/release.yml`
- Added `cdn` job that runs after the `vm` job completes
- Authenticates to AWS via OIDC using `AWS_ROLE_ARN` secret (no long-lived keys)
- Uploads the qcow2 to `s3://polis-releases/{version}/polis-{version}-amd64.qcow2`
- Invalidates CloudFront cache for the new version path
- `release` job now depends on `cdn` completing before creating the GitHub Release

### `scripts/install.sh`
- Added `CDN_BASE_URL` variable (defaults to `https://d1qggvwquwdnma.cloudfront.net`)
- VM image downloads from CloudFront instead of GitHub Releases
- SHA256 checksum verification still uses GitHub Releases as the source (separate origin = tamper-evident)
- CDN URL overridable via `POLIS_CDN_URL` env var for testing

## Required GitHub Secrets

- `AWS_ROLE_ARN` — already added
- `CLOUDFRONT_DIST_ID` — already added

## Security model

Image binary → CloudFront (fast CDN)
Checksum → GitHub Releases (separate origin, tamper-evident)

If either is tampered with independently, the SHA256 verification in install.sh will catch it.