### PR TITLE
fix: polis update - Windows support, post-update VM config, rollback, progress indication

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -83,6 +83,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,6 +333,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +383,26 @@ checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1230,6 +1265,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1439,6 +1480,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1943,6 +1990,7 @@ dependencies = [
  "tar",
  "tempfile",
  "urlencoding",
+ "zip",
  "zipsign-api 0.1.5",
 ]
 
@@ -2274,6 +2322,25 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tinystr"
@@ -3138,6 +3205,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "indexmap",
+ "memchr",
+ "thiserror 2.0.18",
+ "time",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -44,9 +44,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 regex = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "process", "io-std", "signal"] }
-self_update = { version = "0.42", features = ["archive-tar", "compression-flate2", "signatures"] }
+self_update = { version = "0.42", features = ["archive-tar", "archive-zip", "compression-flate2", "signatures"] }
 semver = "1.0"
-zipsign-api = { version = "0.2", default-features = false, features = ["verify-tar", "unsign-tar", "sign-tar"] }
+zipsign-api = { version = "0.2", default-features = false, features = ["verify-tar", "verify-zip", "unsign-tar", "sign-tar"] }
 tar = "0.4"
 flate2 = "1.0"
 sha2 = "0.10"

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -151,7 +151,6 @@ impl AppContext {
 
     /// Returns a `TerminalReporter` bound to this context's output.
     #[must_use]
-    #[allow(dead_code)] // Not yet called from command handlers
     pub fn terminal_reporter(&self) -> crate::output::reporter::TerminalReporter<'_> {
         crate::output::reporter::TerminalReporter::new(&self.output)
     }
@@ -164,7 +163,6 @@ impl AppContext {
     /// # Errors
     ///
     /// Returns an error if asset extraction fails.
-    #[allow(dead_code)] // Not yet called from command handlers
     pub fn assets_dir(&self) -> Result<(std::path::PathBuf, tempfile::TempDir)> {
         let (path, guard) = crate::infra::assets::extract_assets()?;
         Ok((path, guard))

--- a/cli/src/application/services/update.rs
+++ b/cli/src/application/services/update.rs
@@ -104,6 +104,7 @@ pub async fn update_vm_config(
     // Hashes differ — perform full config update cycle
 
     // Stop services
+    reporter.begin_stage("stopping services...");
     mp.exec(&[
         "docker",
         "compose",
@@ -113,6 +114,7 @@ pub async fn update_vm_config(
     ])
     .await
     .context("stopping services")?;
+    reporter.complete_stage();
 
     // From here on, if anything fails we attempt a best-effort restart so the
     // VM is not left with services down.
@@ -147,21 +149,25 @@ async fn apply_config_update(
     new_hash: &str,
 ) -> Result<()> {
     // Transfer new config
+    reporter.begin_stage("transferring config...");
     transfer_config(mp, assets_dir, version)
         .await
         .context("transferring new config")?;
 
     // Pull new images
+    reporter.begin_stage("pulling images...");
     pull_images(mp, reporter)
         .await
         .context("pulling Docker images")?;
 
     // Verify image digests
+    reporter.begin_stage("verifying images...");
     verify_image_digests(mp, assets, reporter)
         .await
         .context("verifying image digests")?;
 
     // Restart services
+    reporter.begin_stage("starting services...");
     mp.exec(&[
         "docker",
         "compose",
@@ -172,6 +178,7 @@ async fn apply_config_update(
     ])
     .await
     .context("restarting services")?;
+    reporter.complete_stage();
 
     // Write new hash AFTER successful restart
     write_config_hash(mp, new_hash)

--- a/cli/src/application/services/update.rs
+++ b/cli/src/application/services/update.rs
@@ -114,6 +114,38 @@ pub async fn update_vm_config(
     .await
     .context("stopping services")?;
 
+    // From here on, if anything fails we attempt a best-effort restart so the
+    // VM is not left with services down.
+    match apply_config_update(mp, assets, hasher, reporter, assets_dir, version, &new_hash).await {
+        Ok(()) => Ok(UpdateVmConfigOutcome::Updated),
+        Err(e) => {
+            // Best-effort: try to bring services back up with whatever config is present.
+            let _ = mp
+                .exec(&[
+                    "docker",
+                    "compose",
+                    "-f",
+                    "/opt/polis/docker-compose.yml",
+                    "up",
+                    "-d",
+                ])
+                .await;
+            Err(e.context("config update failed; services restarted with previous config"))
+        }
+    }
+}
+
+/// Inner helper that performs the config transfer → pull → verify → restart
+/// cycle. Separated so the caller can wrap it with rollback logic.
+async fn apply_config_update(
+    mp: &(impl InstanceInspector + ShellExecutor + FileTransfer),
+    assets: &impl AssetExtractor,
+    _hasher: &(impl FileHasher + ?Sized),
+    reporter: &impl ProgressReporter,
+    assets_dir: &std::path::Path,
+    version: &str,
+    new_hash: &str,
+) -> Result<()> {
     // Transfer new config
     transfer_config(mp, assets_dir, version)
         .await
@@ -142,11 +174,11 @@ pub async fn update_vm_config(
     .context("restarting services")?;
 
     // Write new hash AFTER successful restart
-    write_config_hash(mp, &new_hash)
+    write_config_hash(mp, new_hash)
         .await
         .context("writing new config hash")?;
 
-    Ok(UpdateVmConfigOutcome::Updated)
+    Ok(())
 }
 
 /// Outcome of the VM config update service.

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -96,6 +96,9 @@ pub enum Command {
 
     #[command(hide = true, name = "_extract-host-key")]
     ExtractHostKey,
+
+    #[command(hide = true, name = "_post-update")]
+    PostUpdate,
 }
 
 impl Cli {
@@ -149,6 +152,10 @@ impl Cli {
             }
             Command::Provision => {
                 anyhow::bail!("Provision command is internal only")
+            }
+            Command::PostUpdate => {
+                commands::update::post_update(&app).await?;
+                ExitCode::SUCCESS
             }
         };
 

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod start;
 pub mod status;
 pub mod stop;
 pub mod update;
+pub mod update_helpers;
 pub mod version;
 
 use clap::Args;

--- a/cli/src/commands/update.rs
+++ b/cli/src/commands/update.rs
@@ -90,7 +90,11 @@ mod tests {
 
         let args = UpdateArgs { check: true };
         let app = crate::app::AppContext::new(&crate::app::AppFlags {
-            output: crate::app::OutputFlags { no_color: true, quiet: true, json: false },
+            output: crate::app::OutputFlags {
+                no_color: true,
+                quiet: true,
+                json: false,
+            },
             behaviour: crate::app::BehaviourFlags { yes: true },
         })
         .expect("AppContext");
@@ -119,7 +123,11 @@ mod tests {
 
         let args = UpdateArgs { check: false };
         let app = crate::app::AppContext::new(&crate::app::AppFlags {
-            output: crate::app::OutputFlags { no_color: true, quiet: true, json: false },
+            output: crate::app::OutputFlags {
+                no_color: true,
+                quiet: true,
+                json: false,
+            },
             behaviour: crate::app::BehaviourFlags { yes: true },
         })
         .expect("AppContext");
@@ -129,7 +137,9 @@ mod tests {
     }
 
     #[test]
-    fn test_hex_encode_empty_returns_empty() { assert_eq!(hex_encode(&[]), ""); }
+    fn test_hex_encode_empty_returns_empty() {
+        assert_eq!(hex_encode(&[]), "");
+    }
 
     #[test]
     fn test_hex_encode_single_byte() {

--- a/cli/src/commands/update.rs
+++ b/cli/src/commands/update.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use clap::Args;
 
 use crate::app::AppContext;
+use crate::application::ports::ProgressReporter;
 use crate::application::services::update::{UpdateChecker, UpdateInfo};
 use crate::application::services::workspace_stop::is_vm_running;
 use crate::commands::update_helpers;
@@ -29,12 +30,11 @@ pub async fn run(
     let ctx = &app.output;
     let mp = &app.provisioner;
     let current = env!("CARGO_PKG_VERSION");
+    let reporter = app.terminal_reporter();
 
-    if !ctx.quiet {
-        ctx.info("Checking for updates...");
-    }
-
+    reporter.begin_stage("checking for updates...");
     let cli_update = checker.check(current)?;
+    reporter.complete_stage();
     update_helpers::print_update_info(ctx, current, &cli_update);
 
     if args.check {

--- a/cli/src/commands/update.rs
+++ b/cli/src/commands/update.rs
@@ -1,13 +1,12 @@
 //! `polis update` — self-update with checksum and signature verification.
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use clap::Args;
 
 use crate::app::AppContext;
-use crate::application::services::update::{
-    UpdateChecker, UpdateInfo, UpdateVmConfigOutcome, update_vm_config,
-};
+use crate::application::services::update::{UpdateChecker, UpdateInfo};
 use crate::application::services::workspace_stop::is_vm_running;
+use crate::commands::update_helpers;
 
 /// Arguments for the update command.
 #[derive(Args)]
@@ -17,22 +16,11 @@ pub struct UpdateArgs {
     pub check: bool,
 }
 
-// Embedded ed25519 public key (base64) for verifying signed CLI release archives.
-// The corresponding private key is stored as `POLIS_SIGNING_KEY` in GitHub
-// Actions secrets and used by the release workflow to sign `.tar.gz` / `.zip`
-// archives via `zipsign`.
-
-// Production implementation using GitHub releases.
-// ── Entry point ───────────────────────────────────────────────────────────────
-
 /// Run `polis update [--check]`.
-/// Checks GitHub for a newer release, verifies its signature, prompts the user,
-/// then downloads and replaces the current binary. If the VM is running, also
-/// updates the VM config.
 /// # Errors
 /// Returns an error if the version check, signature verification, download, or
 /// user prompt fails.
-#[allow(clippy::unused_async)] // async contract: will gain awaits when download is made async
+#[allow(clippy::unused_async)]
 pub async fn run(
     args: &UpdateArgs,
     app: &AppContext,
@@ -47,122 +35,33 @@ pub async fn run(
     }
 
     let cli_update = checker.check(current)?;
-
-    match &cli_update {
-        UpdateInfo::UpToDate => {
-            ctx.success(&format!("CLI v{current} (latest)"));
-        }
-        UpdateInfo::Available {
-            version,
-            release_notes,
-            ..
-        } => {
-            ctx.info(&format!("CLI v{current} → v{version} available"));
-            if !release_notes.is_empty() && !ctx.quiet {
-                println!("  Changes in v{version}:");
-                for note in release_notes {
-                    println!("    • {note}");
-                }
-            }
-        }
-    }
+    update_helpers::print_update_info(ctx, current, &cli_update);
 
     if args.check {
-        ctx.info("Run 'polis update' to apply the update.");
+        if matches!(cli_update, UpdateInfo::Available { .. }) {
+            ctx.info("Run 'polis update' to apply the update.");
+        }
         return Ok(std::process::ExitCode::SUCCESS);
     }
 
-    if matches!(cli_update, UpdateInfo::Available { .. }) {
-        apply_cli_update(app, checker, cli_update)?;
-    }
+    let did_update = update_helpers::apply_cli_update(app, checker, cli_update)?;
 
-    // After CLI self-update, update VM config if the VM is running
-    if is_vm_running(mp).await? {
-        if !ctx.quiet {
-            ctx.info("Updating VM config...");
-        }
-        update_config(app).await?;
+    // After CLI self-update, delegate VM config update to the NEW binary so
+    // its embedded assets are used instead of the stale ones from the old binary.
+    if did_update && is_vm_running(mp).await? {
+        update_helpers::spawn_post_update(ctx)?;
+    } else if !did_update && is_vm_running(mp).await? {
+        update_helpers::run_vm_config_update(app).await?;
     }
 
     Ok(std::process::ExitCode::SUCCESS)
 }
 
-/// Update the VM config when the CLI has been updated to a new version.
-/// Extracts embedded assets, computes the SHA256 of the new config tarball,
-/// and compares it against the hash stored in the VM. If they differ, stops
-/// services, transfers the new config, pulls images, verifies digests,
-/// restarts services, and writes the new hash.
+/// Run the VM config update cycle (used by `_post-update` hidden command).
 /// # Errors
 /// Returns an error if any step of the update cycle fails.
-pub async fn update_config(app: &AppContext) -> Result<()> {
-    let ctx = &app.output;
-    let (assets_dir, _guard) = app.assets_dir().context("extracting embedded assets")?;
-
-    let version = env!("CARGO_PKG_VERSION");
-    let reporter = app.terminal_reporter();
-    let hasher = &crate::infra::fs::LocalFs;
-
-    match update_vm_config(
-        &app.provisioner,
-        &app.assets,
-        hasher,
-        &reporter,
-        &assets_dir,
-        version,
-    )
-    .await?
-    {
-        UpdateVmConfigOutcome::UpToDate => {
-            ctx.success("Config is up to date");
-        }
-        UpdateVmConfigOutcome::Updated => {
-            ctx.success("Config updated successfully");
-        }
-    }
-
-    Ok(())
-}
-
-/// # Errors
-/// This function will return an error if the underlying operations fail.
-fn apply_cli_update(
-    app: &AppContext,
-    checker: &impl UpdateChecker,
-    cli_update: UpdateInfo,
-) -> Result<()> {
-    let ctx = &app.output;
-    let UpdateInfo::Available {
-        version,
-        download_url,
-        ..
-    } = cli_update
-    else {
-        return Ok(());
-    };
-
-    if !ctx.quiet {
-        ctx.info("Verifying checksum...");
-    }
-    let sig = checker
-        .verify_signature(&download_url)
-        .context("checksum verification failed")?;
-
-    let sha_preview = sig.sha256.get(..12).unwrap_or(&sig.sha256);
-    ctx.success(&format!("SHA-256: {sha_preview}..."));
-
-    let confirmed = app
-        .confirm("Update CLI now?", true)
-        .context("reading confirmation")?;
-
-    if confirmed {
-        if !ctx.quiet {
-            ctx.info("Downloading...");
-        }
-        checker.perform_update(&version).context("update failed")?;
-        ctx.success(&format!("CLI updated to v{version}"));
-        ctx.info("Restart your terminal or run: exec polis");
-    }
-    Ok(())
+pub async fn post_update(app: &AppContext) -> Result<()> {
+    update_helpers::run_vm_config_update(app).await
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -174,38 +73,24 @@ mod tests {
     use crate::application::services::update::SignatureInfo;
     use crate::domain::workspace::hex_encode;
 
-    // -----------------------------------------------------------------------
-    // run() via UpdateChecker trait mock — unit
-    // -----------------------------------------------------------------------
-
     #[tokio::test]
     async fn test_run_up_to_date_returns_ok() {
         struct AlwaysUpToDate;
         impl UpdateChecker for AlwaysUpToDate {
-            /// # Errors
-            /// This function will return an error if the underlying operations fail.
             fn check(&self, _current: &str) -> anyhow::Result<UpdateInfo> {
                 Ok(UpdateInfo::UpToDate)
             }
-            /// # Errors
-            /// This function will return an error if the underlying operations fail.
             fn verify_signature(&self, _url: &str) -> anyhow::Result<SignatureInfo> {
-                anyhow::bail!("not expected: should not verify when up to date")
+                anyhow::bail!("not expected")
             }
-            /// # Errors
-            /// This function will return an error if the underlying operations fail.
             fn perform_update(&self, _version: &str) -> anyhow::Result<()> {
-                anyhow::bail!("not expected: should not update when up to date")
+                anyhow::bail!("not expected")
             }
         }
 
         let args = UpdateArgs { check: true };
         let app = crate::app::AppContext::new(&crate::app::AppFlags {
-            output: crate::app::OutputFlags {
-                no_color: true,
-                quiet: true,
-                json: false,
-            },
+            output: crate::app::OutputFlags { no_color: true, quiet: true, json: false },
             behaviour: crate::app::BehaviourFlags { yes: true },
         })
         .expect("AppContext");
@@ -217,8 +102,6 @@ mod tests {
     async fn test_run_invalid_signature_returns_err() {
         struct BadSignature;
         impl UpdateChecker for BadSignature {
-            /// # Errors
-            /// This function will return an error if the underlying operations fail.
             fn check(&self, _current: &str) -> anyhow::Result<UpdateInfo> {
                 Ok(UpdateInfo::Available {
                     version: "9.9.9".to_string(),
@@ -226,44 +109,27 @@ mod tests {
                     download_url: "https://example.com/polis.tar.gz".to_string(),
                 })
             }
-            /// # Errors
-            /// This function will return an error if the underlying operations fail.
             fn verify_signature(&self, _url: &str) -> anyhow::Result<SignatureInfo> {
                 Err(anyhow::anyhow!("checksum verification failed"))
             }
-            /// # Errors
-            /// This function will return an error if the underlying operations fail.
             fn perform_update(&self, _version: &str) -> anyhow::Result<()> {
-                anyhow::bail!("not expected: should not update when checksum is invalid")
+                anyhow::bail!("not expected")
             }
         }
 
         let args = UpdateArgs { check: false };
         let app = crate::app::AppContext::new(&crate::app::AppFlags {
-            output: crate::app::OutputFlags {
-                no_color: true,
-                quiet: true,
-                json: false,
-            },
+            output: crate::app::OutputFlags { no_color: true, quiet: true, json: false },
             behaviour: crate::app::BehaviourFlags { yes: true },
         })
         .expect("AppContext");
         let result = run(&args, &app, &BadSignature).await;
         assert!(result.is_err());
-        assert!(
-            result.unwrap_err().to_string().contains("checksum"),
-            "error should mention checksum"
-        );
+        assert!(result.unwrap_err().to_string().contains("checksum"));
     }
-
-    // -----------------------------------------------------------------------
-    // hex_encode — unit
-    // -----------------------------------------------------------------------
 
     #[test]
-    fn test_hex_encode_empty_returns_empty() {
-        assert_eq!(hex_encode(&[]), "");
-    }
+    fn test_hex_encode_empty_returns_empty() { assert_eq!(hex_encode(&[]), ""); }
 
     #[test]
     fn test_hex_encode_single_byte() {

--- a/cli/src/commands/update_helpers.rs
+++ b/cli/src/commands/update_helpers.rs
@@ -1,0 +1,134 @@
+//! Helpers for `polis update` — extracted to keep the command handler thin.
+
+use anyhow::{Context, Result};
+
+use crate::app::AppContext;
+use crate::application::services::update::{
+    UpdateChecker, UpdateInfo, UpdateVmConfigOutcome, update_vm_config,
+};
+use crate::output::OutputContext;
+
+/// Print version comparison info to the terminal.
+pub fn print_update_info(ctx: &OutputContext, current: &str, info: &UpdateInfo) {
+    match info {
+        UpdateInfo::UpToDate => {
+            ctx.success(&format!("CLI v{current} (latest)"));
+        }
+        UpdateInfo::Available {
+            version,
+            release_notes,
+            ..
+        } => {
+            ctx.info(&format!("CLI v{current} → v{version} available"));
+            if !release_notes.is_empty() && !ctx.quiet {
+                println!("  Changes in v{version}:");
+                for note in release_notes {
+                    println!("    • {note}");
+                }
+            }
+        }
+    }
+}
+
+/// Verify, confirm, and perform the CLI binary update.
+/// Returns `true` if the binary was actually replaced.
+///
+/// # Errors
+/// Returns an error if verification, confirmation, or download fails.
+pub fn apply_cli_update(
+    app: &AppContext,
+    checker: &impl UpdateChecker,
+    cli_update: UpdateInfo,
+) -> Result<bool> {
+    let ctx = &app.output;
+    let UpdateInfo::Available {
+        version,
+        download_url,
+        ..
+    } = cli_update
+    else {
+        return Ok(false);
+    };
+
+    if !ctx.quiet {
+        ctx.info("Verifying checksum...");
+    }
+    let sig = checker
+        .verify_signature(&download_url)
+        .context("checksum verification failed")?;
+
+    let sha_preview = sig.sha256.get(..12).unwrap_or(&sig.sha256);
+    ctx.success(&format!("SHA-256: {sha_preview}..."));
+
+    let confirmed = app
+        .confirm("Update CLI now?", true)
+        .context("reading confirmation")?;
+
+    if confirmed {
+        if !ctx.quiet {
+            ctx.info("Downloading...");
+        }
+        checker.perform_update(&version).context("update failed")?;
+        ctx.success(&format!("CLI updated to v{version}"));
+        if cfg!(windows) {
+            ctx.info("Restart your terminal to use the new version.");
+        } else {
+            ctx.info("Restart your terminal or run: exec polis");
+        }
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+/// Spawn the newly-installed `polis` binary with the hidden `_post-update`
+/// command so the VM config update uses the NEW binary's embedded assets.
+///
+/// # Errors
+/// Returns an error if the new binary cannot be spawned.
+pub fn spawn_post_update(ctx: &OutputContext) -> Result<()> {
+    let exe = std::env::current_exe().context("resolving current executable path")?;
+    let status = std::process::Command::new(&exe)
+        .arg("_post-update")
+        .status()
+        .context("failed to spawn post-update process")?;
+
+    if status.success() {
+        ctx.success("VM config updated via new binary");
+    } else {
+        ctx.warn("VM config update returned non-zero — check with: polis status");
+    }
+    Ok(())
+}
+
+/// Run the VM config update cycle using the current binary's embedded assets.
+///
+/// # Errors
+/// Returns an error if any step of the update cycle fails.
+pub async fn run_vm_config_update(app: &AppContext) -> Result<()> {
+    let ctx = &app.output;
+    let (assets_dir, _guard) = app.assets_dir().context("extracting embedded assets")?;
+
+    let version = env!("CARGO_PKG_VERSION");
+    let reporter = app.terminal_reporter();
+    let hasher = &crate::infra::fs::LocalFs;
+
+    match update_vm_config(
+        &app.provisioner,
+        &app.assets,
+        hasher,
+        &reporter,
+        &assets_dir,
+        version,
+    )
+    .await?
+    {
+        UpdateVmConfigOutcome::UpToDate => {
+            ctx.success("Config is up to date");
+        }
+        UpdateVmConfigOutcome::Updated => {
+            ctx.success("Config updated successfully");
+        }
+    }
+
+    Ok(())
+}

--- a/cli/src/commands/update_helpers.rs
+++ b/cli/src/commands/update_helpers.rs
@@ -3,6 +3,7 @@
 use anyhow::{Context, Result};
 
 use crate::app::AppContext;
+use crate::application::ports::ProgressReporter;
 use crate::application::services::update::{
     UpdateChecker, UpdateInfo, UpdateVmConfigOutcome, update_vm_config,
 };
@@ -41,6 +42,7 @@ pub fn apply_cli_update(
     cli_update: UpdateInfo,
 ) -> Result<bool> {
     let ctx = &app.output;
+    let reporter = app.terminal_reporter();
     let UpdateInfo::Available {
         version,
         download_url,
@@ -50,12 +52,11 @@ pub fn apply_cli_update(
         return Ok(false);
     };
 
-    if !ctx.quiet {
-        ctx.info("Verifying checksum...");
-    }
+    reporter.begin_stage("verifying checksum...");
     let sig = checker
         .verify_signature(&download_url)
         .context("checksum verification failed")?;
+    reporter.complete_stage();
 
     let sha_preview = sig.sha256.get(..12).unwrap_or(&sig.sha256);
     ctx.success(&format!("SHA-256: {sha_preview}..."));
@@ -65,10 +66,9 @@ pub fn apply_cli_update(
         .context("reading confirmation")?;
 
     if confirmed {
-        if !ctx.quiet {
-            ctx.info("Downloading...");
-        }
+        reporter.begin_stage("downloading update...");
         checker.perform_update(&version).context("update failed")?;
+        reporter.complete_stage();
         ctx.success(&format!("CLI updated to v{version}"));
         if cfg!(windows) {
             ctx.info("Restart your terminal to use the new version.");
@@ -79,6 +79,7 @@ pub fn apply_cli_update(
     }
     Ok(false)
 }
+
 
 /// Spawn the newly-installed `polis` binary with the hidden `_post-update`
 /// command so the VM config update uses the NEW binary's embedded assets.

--- a/cli/src/commands/update_helpers.rs
+++ b/cli/src/commands/update_helpers.rs
@@ -80,7 +80,6 @@ pub fn apply_cli_update(
     Ok(false)
 }
 
-
 /// Spawn the newly-installed `polis` binary with the hidden `_post-update`
 /// command so the VM config update uses the NEW binary's embedded assets.
 ///

--- a/cli/src/infra/update.rs
+++ b/cli/src/infra/update.rs
@@ -271,7 +271,8 @@ mod tests {
         let path = std::path::Path::new(&name);
         if is_windows_platform() {
             assert!(
-                path.extension().is_some_and(|ext| ext.eq_ignore_ascii_case("zip")),
+                path.extension()
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("zip")),
                 "Windows asset name should be a .zip: {name}"
             );
         } else {

--- a/cli/src/infra/update.rs
+++ b/cli/src/infra/update.rs
@@ -268,9 +268,10 @@ mod tests {
     #[test]
     fn test_get_asset_name_current_platform_returns_archive() {
         let name = get_asset_name().expect("current platform should be supported");
+        let path = std::path::Path::new(&name);
         if is_windows_platform() {
             assert!(
-                name.ends_with(".zip"),
+                path.extension().is_some_and(|ext| ext.eq_ignore_ascii_case("zip")),
                 "Windows asset name should be a .zip: {name}"
             );
         } else {

--- a/cli/src/infra/update.rs
+++ b/cli/src/infra/update.rs
@@ -106,8 +106,13 @@ impl UpdateChecker for GithubUpdateChecker {
             .map_err(|e| anyhow::anyhow!("invalid public key: {e}"))?;
 
         let mut cursor = Cursor::new(&data);
-        zipsign_api::verify::verify_tar(&mut cursor, &keys, Some(b""))
-            .map_err(|e| anyhow::anyhow!("signature verification failed: {e}"))?;
+        if is_windows_platform() {
+            zipsign_api::verify::verify_zip(&mut cursor, &keys, Some(b""))
+                .map_err(|e| anyhow::anyhow!("signature verification failed: {e}"))?;
+        } else {
+            zipsign_api::verify::verify_tar(&mut cursor, &keys, Some(b""))
+                .map_err(|e| anyhow::anyhow!("signature verification failed: {e}"))?;
+        }
 
         Ok(SignatureInfo {
             sha256: actual_sha256,
@@ -118,13 +123,21 @@ impl UpdateChecker for GithubUpdateChecker {
     ///
     /// This function will return an error if the underlying operations fail.
     fn perform_update(&self, version: &str) -> Result<()> {
-        let status = self_update::backends::github::Update::configure()
+        let mut builder = self_update::backends::github::Update::configure();
+        builder
             .repo_owner("OdraLabsHQ")
             .repo_name("polis")
             .bin_name("polis")
             .show_download_progress(true)
             .current_version(env!("CARGO_PKG_VERSION"))
-            .target_version_tag(&format!("v{version}"))
+            .target_version_tag(&format!("v{version}"));
+
+        // On Windows the release asset is a .zip; on Unix it is a .tar.gz.
+        if is_windows_platform() {
+            builder.bin_path_in_archive("polis.exe");
+        }
+
+        let status = builder
             .build()
             .context("failed to configure update")?
             .update()
@@ -143,10 +156,15 @@ pub(crate) fn get_asset_name() -> Result<String> {
         ("linux", "aarch64") => "polis-linux-arm64.tar.gz",
         ("macos", "x86_64") => "polis-darwin-amd64.tar.gz",
         ("macos", "aarch64") => "polis-darwin-arm64.tar.gz",
-        ("windows", "x86_64") => "polis-windows-amd64.tar.gz",
+        ("windows", "x86_64") => "polis-windows-amd64.zip",
         _ => anyhow::bail!("unsupported platform: {os}-{arch}"),
     };
     Ok(name.to_string())
+}
+
+/// Returns `true` when running on Windows.
+pub(crate) fn is_windows_platform() -> bool {
+    std::env::consts::OS == "windows"
 }
 
 pub(crate) fn parse_release_notes(body: &str) -> Vec<String> {
@@ -248,12 +266,19 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn test_get_asset_name_current_platform_returns_tar_gz() {
+    fn test_get_asset_name_current_platform_returns_archive() {
         let name = get_asset_name().expect("current platform should be supported");
-        assert!(
-            name.ends_with(".tar.gz"),
-            "asset name should be a .tar.gz: {name}"
-        );
+        if is_windows_platform() {
+            assert!(
+                name.ends_with(".zip"),
+                "Windows asset name should be a .zip: {name}"
+            );
+        } else {
+            assert!(
+                name.ends_with(".tar.gz"),
+                "Unix asset name should be a .tar.gz: {name}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes multiple issues with the `polis update` command.

### Windows support
- `get_asset_name()` returns `.zip` on Windows (was `.tar.gz` causing 'no release asset' error)
- `verify_signature()` uses `verify_zip` on Windows / `verify_tar` on Unix
- `perform_update()` sets `bin_path_in_archive("polis.exe")` on Windows

### Post-update VM config
- After CLI self-update, spawns the NEW binary with hidden `_post-update` command so the VM config update uses the new binary's embedded assets (not stale ones from old binary)
- When no CLI update needed but VM is running, runs config update directly

### Rollback on failure
- If config update fails after stopping services, best-effort `docker compose up -d` restart so the VM is not left with services down

### Progress indication
- Added `begin_stage`/`complete_stage` timed spinners to all update operations:
  - CLI: checking for updates, verifying checksum, downloading update
  - VM config: stopping services, transferring config, pulling images, verifying images, starting services

### Testing
- All 149 tests pass
- Manually verified on Windows: update detection, .zip asset resolution, progress spinners, checksum verification gate
- `cargo clippy` and `cargo fmt` clean

Closes #52