### PR TITLE
ci: bump the actions group across 1 directory with 9 updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           toolchain: stable
           components: rustfmt, clippy
 
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Check formatting
         run: |
@@ -127,7 +127,7 @@ jobs:
         with:
           toolchain: stable
 
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Test CLI (skip proptests)
         run: cargo test --workspace --manifest-path cli/Cargo.toml -- --skip proptests
@@ -156,7 +156,7 @@ jobs:
         with:
           toolchain: stable
 
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Test CLI proptests
         run: cargo test --workspace --manifest-path cli/Cargo.toml -- proptests
@@ -270,7 +270,7 @@ jobs:
         run: docker pull ghcr.io/googlecontainertools/container-structure-test:1.22.1
 
       - name: Download image artifact
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: polis-images
 
@@ -312,7 +312,7 @@ jobs:
           persist-credentials: false
 
       - name: Download image artifact
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: polis-images
 
@@ -335,7 +335,7 @@ jobs:
             'ghcr.io/odralabshq/${{ matrix.image }}:latest'
 
       - name: Upload Trivy SARIF
-        uses: github/codeql-action/upload-sarif@e34fc2711fb7964ca6850c8a8382121f34745f3b # v4.32.4
+        uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
         with:
           sarif_file: 'trivy-${{ matrix.image }}.sarif'
           category: 'trivy-${{ matrix.image }}'
@@ -365,7 +365,7 @@ jobs:
         run: source ./scripts/ci-helpers.sh && install_sysbox
 
       - name: Download image artifact
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: polis-images
 
@@ -414,7 +414,7 @@ jobs:
         run: source ./scripts/ci-helpers.sh && install_sysbox
 
       - name: Download image artifact
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: polis-images
 
@@ -515,7 +515,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload Semgrep SARIF
-        uses: github/codeql-action/upload-sarif@e34fc2711fb7964ca6850c8a8382121f34745f3b # v4.32.4
+        uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
         with:
           sarif_file: semgrep.sarif
           category: semgrep-sast
@@ -533,7 +533,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkov IaC scan
-        uses: bridgecrewio/checkov-action@99bb2caf247dfd9f03cf984373bc6043d4e32ebf # v12.1347.0
+        uses: bridgecrewio/checkov-action@2fd3901c8feb52417f27f0d9800259a106c1ec1e # v12.3089.0
         with:
           directory: .
           framework: dockerfile github_actions yaml
@@ -541,7 +541,7 @@ jobs:
           soft_fail: true
 
       - name: Upload Checkov SARIF
-        uses: github/codeql-action/upload-sarif@e34fc2711fb7964ca6850c8a8382121f34745f3b # v4.32.4
+        uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
         with:
           sarif_file: results.sarif
           category: checkov-iac
@@ -554,7 +554,7 @@ jobs:
       security-events: write
       contents: read
       actions: read
-    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@8ae4be80636b94886b3c271caad730985ce0611c # v2.3.3
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@a30b4c310bacb7c0635e316e0720e23f0b791cf8 # v2.3.3
     with:
       scan-args: |-
         --include-git-root

--- a/.github/workflows/g3-builder.yml
+++ b/.github/workflows/g3-builder.yml
@@ -47,7 +47,7 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
           file: services/_builders/g3/Dockerfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
           done
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+        uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
 
       - name: Sign images and generate digest manifest
         run: |
@@ -178,70 +178,70 @@ jobs:
           retention-days: 1
 
       - name: Generate SBOM for resolver image
-        uses: anchore/sbom-action@57aae528053a48a3f6235f2d9461b05fbcb7366d # v0.23.1
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-resolver-oss:${{ needs.validate.outputs.version }}
           artifact-name: sbom-resolver.spdx.json
           output-file: .build/sbom-resolver.spdx.json
 
       - name: Generate SBOM for certgen image
-        uses: anchore/sbom-action@57aae528053a48a3f6235f2d9461b05fbcb7366d # v0.23.1
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-certgen-oss:${{ needs.validate.outputs.version }}
           artifact-name: sbom-certgen.spdx.json
           output-file: .build/sbom-certgen.spdx.json
 
       - name: Generate SBOM for gate image
-        uses: anchore/sbom-action@57aae528053a48a3f6235f2d9461b05fbcb7366d # v0.23.1
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-gate-oss:${{ needs.validate.outputs.version }}
           artifact-name: sbom-gate.spdx.json
           output-file: .build/sbom-gate.spdx.json
 
       - name: Generate SBOM for sentinel image
-        uses: anchore/sbom-action@57aae528053a48a3f6235f2d9461b05fbcb7366d # v0.23.1
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-sentinel-oss:${{ needs.validate.outputs.version }}
           artifact-name: sbom-sentinel.spdx.json
           output-file: .build/sbom-sentinel.spdx.json
 
       - name: Generate SBOM for scanner image
-        uses: anchore/sbom-action@57aae528053a48a3f6235f2d9461b05fbcb7366d # v0.23.1
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-scanner-oss:${{ needs.validate.outputs.version }}
           artifact-name: sbom-scanner.spdx.json
           output-file: .build/sbom-scanner.spdx.json
 
       - name: Generate SBOM for workspace image
-        uses: anchore/sbom-action@57aae528053a48a3f6235f2d9461b05fbcb7366d # v0.23.1
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-workspace-oss:${{ needs.validate.outputs.version }}
           artifact-name: sbom-workspace.spdx.json
           output-file: .build/sbom-workspace.spdx.json
 
       - name: Generate SBOM for init image
-        uses: anchore/sbom-action@57aae528053a48a3f6235f2d9461b05fbcb7366d # v0.23.1
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-init-oss:${{ needs.validate.outputs.version }}
           artifact-name: sbom-init.spdx.json
           output-file: .build/sbom-init.spdx.json
 
       - name: Generate SBOM for state image
-        uses: anchore/sbom-action@57aae528053a48a3f6235f2d9461b05fbcb7366d # v0.23.1
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-state-oss:${{ needs.validate.outputs.version }}
           artifact-name: sbom-state.spdx.json
           output-file: .build/sbom-state.spdx.json
 
       - name: Generate SBOM for toolbox image
-        uses: anchore/sbom-action@57aae528053a48a3f6235f2d9461b05fbcb7366d # v0.23.1
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-toolbox-oss:${{ needs.validate.outputs.version }}
           artifact-name: sbom-toolbox.spdx.json
           output-file: .build/sbom-toolbox.spdx.json
 
       - name: Generate SBOM for control-plane image
-        uses: anchore/sbom-action@57aae528053a48a3f6235f2d9461b05fbcb7366d # v0.23.1
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-control-plane-oss:${{ needs.validate.outputs.version }}
           artifact-name: sbom-control-plane.spdx.json
@@ -263,7 +263,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download image-digests artifact
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: image-digests
           path: .build/
@@ -333,7 +333,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download prepared assets
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: prepared-assets
           path: .build/assets/
@@ -472,20 +472,20 @@ jobs:
           fi
 
       - name: Download CLI artifacts
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: cli-*
           path: ./cli-bin
           merge-multiple: true
 
       - name: Download image-digests artifact
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: image-digests
           path: ./release-assets
 
       - name: Download SBOMs artifacts
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: sbom-*
           path: ./release-assets
@@ -495,7 +495,7 @@ jobs:
         run: mkdir -p release-assets
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         with:
           tag_name: ${{ needs.validate.outputs.tag_name }}
           name: Polis ${{ needs.validate.outputs.version }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -24,7 +24,7 @@ jobs:
           results_format: sarif
           publish_results: true
 
-      - uses: github/codeql-action/upload-sarif@e34fc2711fb7964ca6850c8a8382121f34745f3b # v4.32.4
+      - uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
         with:
           sarif_file: scorecard.sarif
           category: ossf-scorecard


### PR DESCRIPTION
Resolves conflicts from PR #67 by applying dependabot version bumps to the current develop branch.

Updates:
- Swatinem/rust-cache: v2.8.2 → v2.9.1
- actions/download-artifact: v8.0.0 → v8.0.1
- github/codeql-action: e34fc27 → 89a39a4
- bridgecrewio/checkov-action: v12.1347.0 → v12.3089.0
- google/osv-scanner-action: 8ae4be8 → a30b4c3
- docker/build-push-action: v6.19.2 → v7.0.0
- sigstore/cosign-installer: v4.0.0 → v4.1.0
- anchore/sbom-action: v0.23.1 → v0.24.0
- softprops/action-gh-release: v2.5.0 → v2.6.1